### PR TITLE
Added initial framework for persistant task queue

### DIFF
--- a/R/rworker.R
+++ b/R/rworker.R
@@ -112,8 +112,8 @@ Rworker <- R6::R6Class(
         },
 
         # Create and register new task 
-        task = function(FUN, name, ...) {
-            private$tasklist[[name]] = FUN
+        task = function(FUN, name, task_structure = NULL, ...) {
+            private$tasklist[[name]] = list('FUN' = FUN, 'task_structure' = task_structure)
         },
 
         # Listen for new messages from message queue
@@ -132,7 +132,7 @@ Rworker <- R6::R6Class(
                     # send job to worker
                     if (!is.null(msg)){
                         tereq = ter(msg)
-                        tereq$task = self$tasks[[tereq$taskname]]
+                        tereq$task = self$tasks[[tereq$taskname]][['FUN']]
                         log_it(glue::glue("Received task {tereq$task_id}: {tereq$taskname}"), 'info')
                         self$execute(tereq)
                     }

--- a/task_queue/queue/queue_class.R
+++ b/task_queue/queue/queue_class.R
@@ -1,0 +1,261 @@
+#R6 Class for Task
+
+# Notes: 
+# Create a task using $create_task(), or directly supply a task function to
+# $queue_task(). Otherwise, supplying a task name matching one in tasks_list() will 
+# also be pushed to the Redis queue. After that, use TaskQueueR::rwork$consume() to 
+# spawn the worker processes to execute the tasks. 
+
+
+# For Demo Purposes:
+library(R6)
+library(rworker)
+library(redux)
+library(callr)
+library(tidyr)
+library(jsonlite)
+
+
+library(dash)
+library(dashCoreComponents)
+library(dashHtmlComponents)
+
+# test_task <- (function(){1+1})
+
+
+###################################################################################
+
+R6_Task_QueueR <- R6Class('TaskQueueR', 
+                          public = list(
+                            con = redux::hiredis(),
+                            worker_list = list(),
+                            tasks_list = list(),
+                            rwork = rworker(name='celery', queue='redis://localhost:6379', backend='redis://localhost:6379', workers=2),
+
+                            create_task = function(fun, task_name = id_generator(1)) {
+                              self$tasks_list[[task_name]] <- fun
+                              invisible(self)
+                            },
+                            
+                            queue_task = function(task = NULL, task_name = private$id_generator(1), priority = 0, delivery_tag = 'default_delivery'){
+                              if(!is.function(task) && !is.null(task)) stop('Task must be defined as a function.')
+                              
+                              task_structure <- list(
+                                'body' = 'W1tdLCB7fSwgeyJjYWxsYmFja3MiOiBudWxsLCAiZXJyYmFja3MiOiBudWxsLCAiY2hhaW4iOiBudWxsLCAiY2hvcmQiOiBudWxsfV0=',
+                                'content-encoding' = 'utf-8',
+                                'content-type' = 'application/json',
+                                'headers' = list(
+                                  'lang' = 'r',
+                                  'task' = task_name,
+                                  'id' = task_name,
+                                  'shadow' = NULL,
+                                  'eta' = NULL,
+                                  'expires' = NULL,
+                                  'group' = NULL,
+                                  'retries' = 0,
+                                  'timelimit' = c(NA, NA),
+                                  'root_id' = task_name,
+                                  'parent_id' = NULL, 
+                                  'argsrepr' = '()',
+                                  'kwargsrepr' = '{}',
+                                  'origin' = Sys.info()[['nodename']]
+                                ),
+                                'properties' = list(
+                                  'correlation_id' = task_name,
+                                  'reply_to' = delivery_tag,
+                                  'delivery_mode' = 2,
+                                  'delivery_info' = list(
+                                    'exchange' = '',
+                                    'routing_key' = 'celery'
+                                  ),
+                                  'priority' = priority,
+                                  'body_encoding' = 'base64',
+                                  'delivery_tag' = delivery_tag
+                                )
+                              )
+                              
+                              task_JSON <- private$to_JSON(task_structure)
+                              
+                              if(task_name %in% names(self$tasks_list)) {
+                                self$rwork$task(FUN = self$tasks_list[[task_name]], name = task_name, task_structure = task_JSON)
+                              }
+                              else if (!(task_name %in% names(self$tasks_list))) {
+                                self$tasks_list[[task_name]] = task
+                                self$rwork$task(FUN = task, name = task_name, task_structure = task_JSON)
+                              }
+                              
+                              self$con$SET('update', 'TRUE')
+                              invisible(self)
+                            },
+                            
+                            task_result = function(task_name) {
+                              if (!(task_name %in% names(self$rwork$tasks))) stop('Task does not exist or has not been queued.')
+                              
+                              tryCatch(
+                                expr = {
+                                  result_JSON <- self$con$GET(paste0('celery-task-meta-', task_name))
+                                  
+                                  result_string <- fromJSON(result_JSON)
+                                  
+                                  return(result_string$result$result)
+                                },
+                                error = function(e) {
+                                  message('Error! Task may have failed or has not been executed yet. See error below.')
+                                  print(e)
+                                },
+                                warning = function(w) {
+                                  message('Warning! Check syntax or task structure. See warning below.')
+                                  print(w)
+                                },
+                                finally = {
+                                  message('Quitting...')
+                                }
+                              )
+                            },
+                            
+                            send_tasks = function() {
+                              rwork_object <- serialize(self$rwork, connection = NULL)
+                              self$con$SET('rwork', rwork_object)
+                            }
+                          ),
+                          private = list(
+                            id_generator = function(n = 1000) {
+                              generate_letters <- do.call(paste0, replicate(5, sample(LETTERS, n, TRUE), FALSE))
+                              paste0(generate_letters, sprintf('%04d', sample(9999, n, TRUE)), sample(LETTERS, n, TRUE))
+                            },
+                            
+                            to_JSON = function (x, ...) {
+                              jsonlite::toJSON(x, digits = 50, auto_unbox = TRUE, force = TRUE, 
+                                               null = 'null', na = 'null', ...)
+                            }
+                          )
+)
+
+
+TaskQueueR <- function(){
+  R6_Task_QueueR$new()
+}
+
+###################################################################################
+# Working example
+
+# Define the class
+tq <- TaskQueueR()
+
+
+# Create and queue tests
+tq$queue_task(task = function(){1+1}, task_name = 'my-task')
+tq$queue_task(task = function(){2+1}, task_name = 'my-task-2')
+
+# View currently queued tasks
+tq$tasks_list
+
+# Send tasks to Redis server 
+tq$send_tasks()
+
+
+# Get task results
+tq$task_result('my-task')
+tq$task_result('my-task-2')
+
+
+###################################################################################
+# Dash App WIP example/test
+
+app <- Dash$new()
+
+app$layout(htmlDiv(list(
+  htmlP('Task: Find the sum of two numbers.'),
+  dccInput(id='input-1', type='number', value = 5),
+  dccInput(id='input-2', type='number', value = 2),
+  htmlButton(id='submit', children = 'Queue Task', n_clicks = 0),
+  htmlButton(id='consume', children = 'Consume Tasks', n_clicks = 0),
+  htmlDiv(id='tasks'),
+  htmlDiv(id='results'),
+  
+  dccStore(id='store'),
+  # dccInterval(id = 'interval', interval = 5*1000, n_intervals = 0),
+  htmlDiv(id='trash')
+)))
+
+
+app$callback(
+  output(id='tasks', property='children'),
+  params = list(
+    input(id='submit', property = 'n_clicks'),
+    state(id='input-1', property = 'value'),
+    state(id='input-2', property = 'value')
+  ),
+  
+  queue_task <- function(n_clicks, input1, input2) {
+    if(n_clicks > 0) {
+      task_name = sprintf('sum_of_%s_and_%s', input1, input2)
+      a = input1
+      b = input2
+      tq$queue_task(task = function(){a + b}, task_name = task_name)
+    }
+    return(names(tq$tasks_list))
+  }
+)
+
+app$callback(
+  output(id = 'trash', property = 'children'),
+  params = list(
+    input(id = 'consume', property = 'n_clicks')
+  ),
+  consume_tasks <- function(n_clicks){
+    if (n_clicks > 0) {
+      tq$consume()
+      return('Consuming')
+    }
+    return('Standing By')
+  }
+)
+
+
+# app$callback(
+#   output(id = 'store', property = 'data'),
+#   params = list(
+#     input(id = 'interval', property = 'n_intervals')
+#   ),
+#   update_store <- function(n){
+#     results <- c()
+#     
+#     for (n in names(tq$tasks_list)){
+#       task_name <- paste0('celery-task-meta-', n)
+#       results <- c(results, tq$task_result(task_name))
+#     }
+#     
+#     return(results)
+#   }
+# )
+
+
+# app$callback(
+#   output(id= 'results', property = 'children'),
+#   params = list(
+#     input(id = 'store', property = 'data'),
+#     input(id = 'interval', property = 'n_intervals')
+#   ),
+#   
+#   update_results <- function(data, n){
+#     print(data)
+#     return(data[[1]])
+#   }
+# )
+
+
+
+app$run_server(showcase = TRUE, debug = FALSE)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/task_queue/worker/worker.R
+++ b/task_queue/worker/worker.R
@@ -1,0 +1,74 @@
+# Worker Script - This will be executed in a separate container from the task_queue.
+# The worker script uses later to check for any updates to the task object hosted on redis.
+# Every interval it will update the object.
+
+# Then, if it is different, it will restart the callR session to enable the R worker while
+# executing the updated tasks list. 
+
+library(rworker)
+library(callr)
+library(redux)
+library(later)
+
+con = redux::hiredis()
+
+# RWorker Process Logic
+# This checks that the update key is TRUE, then checks for the persistant
+# R session status. If it's running, the tree is killed, then restarted. The
+# persistant session pulls the RWork object and unserializes it from Redis, then 
+# sends the tasks found in tasks list to Redis, which are executed by the rworker subprocesses.
+
+rworker_process <- function() {
+  if (con$GET('update')){
+    if (exists('rs') && rs$get_state() == "busy") {
+      rs$kill_tree()
+      print("Tree Killed")
+      Sys.sleep(10)
+    }
+    
+  if (!is.null(con$GET('rwork'))){
+    rs <- r_session$new()
+    
+    rs$call(function() {
+      library(rworker)
+      library(redux)
+      
+      con <- redux::hiredis()
+      rwork_object <- con$GET("rwork")
+      rwork <- unserialize(rwork_object)
+      # Print the list of tasks
+      rwork$tasks
+      
+      for (task in rwork$tasks){
+        task_to_send <- task$task_structure
+        
+        con$RPUSH('celery', task_to_send)
+      }
+      
+      rwork$consume()
+      
+      con$SET('update', 'FALSE')
+    })
+  }
+  }
+}
+
+
+# NEED TO TEST/CHANGE - WIP
+# Heartbeat Process - This uses the later package as a heartbeat to recursively 
+# execute the Rworker logic at a scheduled interval every 10 seconds. This might need 
+# some finetuning, but it serves as a solution for the time being.
+
+i = 0
+f = function() {
+  if (i %% 1000 == 0) {
+    print(i)
+    rworker_process()
+  }
+  i <<- i + 1
+  later::later(f, 0.001)
+}
+f()
+
+
+


### PR DESCRIPTION
This draft PR introduces the task queue framework for R as discussed in plotly/dash-core#177. 

The task queue assumes there's 3 moving parts, the **client** (where the task class, variables, and possible Dash app can be defined) , the **Redis** message broker, and the **worker** which actually executes the tasks using slave subprocesses. 

In the current implementation it's assumed that the Client and Worker exist in separate containers, with unique working directories and environments. The Redis server will be the communication avenue for these 2 entities with the `update` and `rwork` keys containing the rworker object. 

Tasks can be defined in the Client session, or sourced from a separate `tasks.R` file. In either case, the task is then defined in the rworker object using the `task_queue$queue(FUN, name)` method. The serialized JSON task structure that would mimic the Celery task structure is then added privately to the task. With the `task_queue$send_tasks()` method, the rworker object with the defined tasks is serialized and sent to Redis.

The worker, running a heartbeat, checks for the update trigger at a set interval, and updates the rworker object with the newly defined tasks. It sends the task structure to Redis, and then spawns slave worker processes to execute them. If slaves are already running, it will kill the slave process tree before restarting them so they have the updated rworker object. 

**TO DO**
- [ ] Fix the heartbeat process so that it doesn't infinitely create slave processes. 
- [ ] Add status and update checks to task class. 
- [ ] Add more celery-like task features, worker customization.
- [ ] Test integration within a Dash app.
- [ ] Test with a deployed application with containerized client and worker. 